### PR TITLE
notifyStepClicked before scroll/draw

### DIFF
--- a/projects/ngx-joyride/src/lib/services/joyride-step.service.ts
+++ b/projects/ngx-joyride/src/lib/services/joyride-step.service.ts
@@ -144,12 +144,12 @@ export class JoyrideStepService implements IJoyrideStepService {
         this.currentStep = this.stepsContainerService.get(actionType);
 
         if (this.currentStep == null) throw new JoyrideStepDoesNotExist('');
+        this.notifyStepClicked(actionType);
         // Scroll the element to get it visible if it's in a scrollable element
         this.scrollIfElementBeyondOtherElements();
         this.backDropService.draw(this.currentStep);
         this.drawStep(this.currentStep);
         this.scrollIfStepAndTargetAreNotVisible();
-        this.notifyStepClicked(actionType);
     }
 
     private notifyStepClicked(actionType: StepActionType) {


### PR DESCRIPTION
Implementing any *ngIf changes in the next() subscriber doesn't do any good if the subscriber isn't notified until after the step is scrolled to and drawn.  We have to notify first, so any next() behavior runs, then draw the step.